### PR TITLE
Support Line/Block Comments & Abondon non-ascii support

### DIFF
--- a/tokenizer/helpers.go
+++ b/tokenizer/helpers.go
@@ -1,7 +1,0 @@
-package tokenizer
-
-import "io"
-
-func removeComments(r io.Reader) io.Reader {
-	return nil
-}

--- a/tokenizer/runner.go
+++ b/tokenizer/runner.go
@@ -3,13 +3,25 @@ package tokenizer
 import "io"
 
 func ToXML(dst io.Writer, t *Tokenizer) error {
+	if _, err := io.WriteString(dst, "<tokens>\n"); err != nil {
+		return err
+	}
+	defer io.WriteString(dst, "</tokens>")
 loop:
 	for t.HasMoreTokens() {
 		t.Advance()
 		switch t.currentToken.tokenType {
 		case EOF:
 			break loop
+		case SYMBOL:
+			if _, err := io.WriteString(dst, symbolTag(t.currentToken)); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+func symbolTag(tk token) string {
+	return "<symbol> " + tk.symbol + " </symbol>\n"
 }

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -31,6 +31,7 @@ func (t *Tokenizer) HasMoreTokens() bool {
 // 次のトークンを取得し、それをカレントトークンとする.
 // HasMoreTokens()がtrueの場合のみ呼び出すことができる
 func (t *Tokenizer) Advance() {
+	t.skipDelimiters()
 	if t.pos >= len(t.sourceCode) {
 		t.hasMoreTokens = false
 		t.currentToken = token{tokenType: EOF}
@@ -51,6 +52,12 @@ func (t *Tokenizer) Advance() {
 
 func isSymbol(r rune) bool {
 	return strings.ContainsRune("{}()[].,;+-*/&|<>=~", r)
+}
+
+func (t *Tokenizer) skipDelimiters() {
+	for t.pos < len(t.sourceCode) && isDelimiter(rune(t.sourceCode[t.pos])) {
+		t.pos++
+	}
 }
 
 func isDelimiter(r rune) bool {

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -12,6 +12,7 @@ type Tokenizer struct {
 	r             *bufio.Reader
 	hasMoreTokens bool
 	currentToken  token
+	currentLine   string
 }
 
 // NewTokenizer

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -35,9 +35,14 @@ func (t *Tokenizer) currentLetter() rune {
 // 次のトークンを取得し、それをカレントトークンとする.
 // HasMoreTokens()がtrueの場合のみ呼び出すことができる
 func (t *Tokenizer) Advance() {
+	if t.atEOF() {
+		t.hasMoreTokens = false
+		t.currentToken = token{tokenType: EOF}
+		return
+	}
 	// skip spaces, tabs, and line separators
-	t.skipDelimiters()
-	if t.pos >= len(t.sourceCode) {
+	t.skipDelimitersOrComments()
+	if t.atEOF() {
 		t.hasMoreTokens = false
 		t.currentToken = token{tokenType: EOF}
 		return
@@ -58,14 +63,86 @@ func (t *Tokenizer) Advance() {
 	panic("undefined")
 }
 
+func (t *Tokenizer) atEOF() bool {
+	return t.pos >= len(t.sourceCode)
+}
+
 func isSymbol(r rune) bool {
 	return strings.ContainsRune("{}()[].,;+-*/&|<>=~", r)
+}
+
+func (t *Tokenizer) skipDelimitersOrComments() {
+	for t.atCommentStart() || t.atDelimiters() {
+		t.skipDelimiters()
+		t.skipLineComment()
+		t.skipBlockComment()
+	}
 }
 
 func (t *Tokenizer) skipDelimiters() {
 	for t.pos < len(t.sourceCode) && isDelimiter(rune(t.sourceCode[t.pos])) {
 		t.pos++
 	}
+}
+
+func (t *Tokenizer) atDelimiters() bool {
+	return !t.atEOF() && isDelimiter(t.currentLetter())
+}
+
+func (t *Tokenizer) skipLineComment() {
+	if t.atCommentStart() {
+		t.skipUntilLF()
+	}
+}
+
+// いまいる位置にコメントの開始シーケンスが存在するかどうかを返す
+func (t *Tokenizer) atCommentStart() bool {
+	if t.atLineCommentStart() {
+		return true
+	}
+	return t.atBlockCommentStart()
+}
+
+func (t *Tokenizer) atLineCommentStart() bool {
+	if t.pos >= len(t.sourceCode)-1 { // 最後の1文字ならコメントの開始にはならない
+		return false
+	}
+	return t.sourceCode[t.pos:t.pos+2] == "//"
+}
+
+func (t *Tokenizer) skipBlockComment() {
+	if t.atBlockCommentStart() {
+		t.skipUntilBlockCommentEnd()
+	}
+}
+
+func (t *Tokenizer) atBlockCommentStart() bool {
+	if t.pos >= len(t.sourceCode)-2 { // 最後の2文字以降ならブロックコメントの開始にはならない
+		return false
+	}
+	return t.sourceCode[t.pos:t.pos+3] == "/**"
+}
+
+func (t *Tokenizer) atBlockCommentEnd() bool {
+	if t.pos < 2 { // 最低でも3文字目以降でなければならない
+		return false
+	}
+	return t.sourceCode[t.pos-2:t.pos] == "*/"
+}
+
+func (t *Tokenizer) skipUntilLF() {
+	for t.pos < len(t.sourceCode) && t.currentLetter() != '\n' {
+		t.pos++
+	}
+}
+
+func (t *Tokenizer) skipUntilBlockCommentEnd() {
+	for t.pos < len(t.sourceCode) {
+		if t.atBlockCommentEnd() {
+			return
+		}
+	}
+	panic("Block comment begins, but does not ends properly")
 }
 
 func isDelimiter(r rune) bool {

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -28,21 +28,29 @@ func (t *Tokenizer) HasMoreTokens() bool {
 	return t.hasMoreTokens
 }
 
+func (t *Tokenizer) currentLetter() rune {
+	return rune(t.sourceCode[t.pos])
+}
+
 // 次のトークンを取得し、それをカレントトークンとする.
 // HasMoreTokens()がtrueの場合のみ呼び出すことができる
 func (t *Tokenizer) Advance() {
+	// skip spaces, tabs, and line separators
 	t.skipDelimiters()
 	if t.pos >= len(t.sourceCode) {
 		t.hasMoreTokens = false
 		t.currentToken = token{tokenType: EOF}
 		return
 	}
-	// if err != nil {
-	// 	panic(err)
-	// }
-	// skip spaces, tabs, and line separators
 	// symbol
-
+	if isSymbol(t.currentLetter()) {
+		t.currentToken = token{
+			tokenType: SYMBOL,
+			symbol:    string(t.currentLetter()),
+		}
+		t.pos++
+		return
+	}
 	// int_const
 	// string_const
 	// keyword

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -15,7 +15,7 @@ func TestTokenizer_SmallSource(t *testing.T) {
 	}{
 		{"", "<tokens>\n</tokens>"},
 		{"\r \t\n\n\t", "<tokens>\n</tokens>"},
-		// {"{", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
+		{"{", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
 		// {"{//}", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
 	}
 	for _, tc := range testcases {

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -16,7 +16,7 @@ func TestTokenizer_SmallSource(t *testing.T) {
 		{"", "<tokens>\n</tokens>"},
 		{"\r \t\n\n\t", "<tokens>\n</tokens>"},
 		{"{", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
-		// {"{//}", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
+		{"\r\n { /**hello*/\n\r \t//\t }\n", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
 	}
 	for _, tc := range testcases {
 		t.Run("", func(t *testing.T) {

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -17,6 +17,7 @@ func TestTokenizer_SmallSource(t *testing.T) {
 		{"\r \t\n\n\t", "<tokens>\n</tokens>"},
 		{"{", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
 		{"\r\n { /**hello*/\n\r \t//\t }\n", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
+		{"{*", "<tokens>\n<symbol> { </symbol>\n<symbol> * </symbol>\n</tokens>"},
 	}
 	for _, tc := range testcases {
 		t.Run("", func(t *testing.T) {

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -15,7 +15,7 @@ func TestTokenizer_SmallSource(t *testing.T) {
 	}{
 		{"", "<tokens>\n</tokens>"},
 		{"\r \t\n\n\t", "<tokens>\n</tokens>"},
-		{"{", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
+		// {"{", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
 		// {"{//}", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
 	}
 	for _, tc := range testcases {

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -16,6 +16,7 @@ func TestTokenizer_SmallSource(t *testing.T) {
 		{"", "<tokens>\n</tokens>"},
 		{"\r \t\n\n\t", "<tokens>\n</tokens>"},
 		{"{", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
+		// {"{//}", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
 	}
 	for _, tc := range testcases {
 		t.Run("", func(t *testing.T) {

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -13,11 +13,12 @@ func TestTokenizer_SmallSource(t *testing.T) {
 		src  string
 		want string
 	}{
-		{"", ""},
-		{"\r \t\n\n\t", ""},
+		{"", "<tokens>\n</tokens>"},
+		{"\r \t\n\n\t", "<tokens>\n</tokens>"},
+		{"{", "<tokens>\n<symbol> { </symbol>\n</tokens>"},
 	}
 	for _, tc := range testcases {
-		t.Run(tc.src, func(t *testing.T) {
+		t.Run("", func(t *testing.T) {
 			tnzr := tokenizer.NewTokenizer(strings.NewReader(tc.src))
 			var dst strings.Builder
 			if err := tokenizer.ToXML(&dst, tnzr); err != nil {


### PR DESCRIPTION
- implement symbol
- Refactor
- stringとしてソースコードを全部もつかたちにかきなおす
- support delimiters (assuming ASCII)
- Support symbol
- Process line/block comments
- Add symbol test
